### PR TITLE
prometheus와 granfana를 이용한 모니터링 대쉬보드 구축

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# Use the official Gradle image to create a build artifact.
+FROM gradle:8.8-jdk17 AS build
+WORKDIR /home/app
+COPY build.gradle settings.gradle ./
+COPY src ./src
+RUN gradle build -x test
+
+# Use the official OpenJDK image to run the application
+FROM openjdk:17-jdk-slim
+COPY --from=build /home/app/build/libs/*.jar /usr/local/lib/app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/usr/local/lib/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3.7'
+
+services:
+  spring-app:
+    build: .
+    container_name: spring-app
+    ports:
+      - "8080:8080"
+    networks:
+      - monitoring
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    volumes:
+      - ./prometheus/config/prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    networks:
+      - monitoring
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - grafana-storage:/var/lib/grafana
+    depends_on:
+      - prometheus
+      - spring-app
+    networks:
+      - monitoring
+
+volumes:
+  grafana-storage:
+
+networks:
+  monitoring:
+    driver: bridge

--- a/prometheus/config/prometheus.yml
+++ b/prometheus/config/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'spring-app'
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['spring-app:8080']


### PR DESCRIPTION
prometheus 및 metric을 위한 actuator dependency 추가

application의 metric을 prometheus로 추적하기위해 prometheus.yml 파일 생성 및 해당 내용 추가

application을 docker를 이용해 배포하기 위해 dockerfile 생성 및 작성

docker-compose.yml을 이용해서 application, grafana, prometheus 모두 이미지 생성 및 배포





